### PR TITLE
Add axis formatting to give year as four digits

### DIFF
--- a/microsim-gui/src/main/java/microsim/gui/plot/TimeSeriesSimulationPlotter.java
+++ b/microsim-gui/src/main/java/microsim/gui/plot/TimeSeriesSimulationPlotter.java
@@ -3,6 +3,7 @@ package microsim.gui.plot;
 import java.awt.*;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
+import java.text.DecimalFormat;
 import java.util.ArrayList;
 
 import javax.swing.JInternalFrame;
@@ -25,6 +26,7 @@ import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.JFreeChart;
 import org.jfree.chart.axis.NumberAxis;
+import org.jfree.chart.axis.NumberTickUnit;
 import org.jfree.chart.plot.PlotOrientation;
 import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYLineAndShapeRenderer;
@@ -122,6 +124,11 @@ public class TimeSeriesSimulationPlotter extends JInternalFrame implements Event
 //        renderer.setSeriesShapesVisible(1, false);
 
         plot.setRenderer(renderer);
+
+        NumberAxis yearaxis = (NumberAxis) plot.getDomainAxis();
+        yearaxis.setNumberFormatOverride(new DecimalFormat("0000"));
+        yearaxis.setTickUnit(new NumberTickUnit(1));
+
 
 
         // change the auto tick unit selection to integer units only...


### PR DESCRIPTION
This is a tiny edit to tweak graph displays of time series graphs.

- All years are displayed as four digits, with no commas
- Intervals are set to one yearly ticks to leave out decimal spacing of non-simulated points between years

<img width="761" height="308" alt="image" src="https://github.com/user-attachments/assets/daca9457-59d3-4c19-964a-f4c147115acb" />
